### PR TITLE
5 point 0 0 normalization not implemented

### DIFF
--- a/Geometrica/DataStructures/ConvexHull.cs
+++ b/Geometrica/DataStructures/ConvexHull.cs
@@ -258,7 +258,7 @@ public class ConvexHull : IEnumerable<Point2>, IPolygon
         var angle = new double[points.Length];
         for (var i = 0; i < points.Length; i++)
         {
-            angle[i] = GetPointAngle((points[i] - innerPoint).Normalize());
+            angle[i] = Equals(points[i], innerPoint) ? 0 : GetPointAngle((points[i] - innerPoint).Normalize());
         }
         Array.Sort(angle, points);
 

--- a/Geometrica/Primitives/Point2.cs
+++ b/Geometrica/Primitives/Point2.cs
@@ -38,6 +38,10 @@ public struct Point2
     public Point2 Normalize()
     {
         var length = Length();
+        if (length < double.Epsilon)
+        {
+            throw new ArithmeticException($"The point {ToString()} cannot be normalized, because its length is {length}.");
+        }
         return new Point2(X / length, Y / length);
     }
 

--- a/GeometricaTests/PointTests.cs
+++ b/GeometricaTests/PointTests.cs
@@ -7,7 +7,7 @@ namespace GeometricaTests;
 public class PointTests
 {
     [TestMethod]
-    [ExpectedException(typeof(Exception))]
+    [ExpectedException(typeof(ArithmeticException))]
     public void Point_OfZeroLength_CannotBeNormalized()
     {
         var p = new Point2();

--- a/GeometricaTests/PointTests.cs
+++ b/GeometricaTests/PointTests.cs
@@ -7,6 +7,15 @@ namespace GeometricaTests;
 public class PointTests
 {
     [TestMethod]
+    [ExpectedException(typeof(Exception))]
+    public void Point_OfZeroLength_CannotBeNormalized()
+    {
+        var p = new Point2();
+
+        p.Normalize();
+    }
+
+    [TestMethod]
     public void Point_Length_Default()
     {
         var p = new Point2();


### PR DESCRIPTION
Implemented to throw an exception when attempting to normalize (0, 0).
Also fixed emerging bug in point-angle sort in convex hull.